### PR TITLE
Handling async callbacks that execute after onDestroy is called

### DIFF
--- a/app/src/main/java/com/codepath/apps/restclienttemplate/ComposeActivity.java
+++ b/app/src/main/java/com/codepath/apps/restclienttemplate/ComposeActivity.java
@@ -53,7 +53,7 @@ public class ComposeActivity extends AppCompatActivity {
                 if (!isTweetValid(tweetContent, activity)) return;
                 // make API call to twitter to publish the tweet
 
-//                Toast.makeText(ComposeActivity.this, tweetContent, Toast.LENGTH_LONG).show();
+                // TODO: add support for the replied tweet to immediately appear on the timeline
                 mClient.publishTweet(tweetContent, null,
                         TwitterClient.getPublishTweetHandler(activity));
             }

--- a/app/src/main/java/com/codepath/apps/restclienttemplate/TimelineActivity.java
+++ b/app/src/main/java/com/codepath/apps/restclienttemplate/TimelineActivity.java
@@ -109,6 +109,13 @@ public class TimelineActivity extends AppCompatActivity {
     protected void onDestroy() {
         Log.d("TimelineActivity", "destroying");
         super.onDestroy();
+
+        mSwipeContainer = null;
+        mClient = null;
+        mRvTweets = null;
+        mTweets = null;
+        mAdapter = null;
+
     }
 
 
@@ -117,6 +124,7 @@ public class TimelineActivity extends AppCompatActivity {
             @Override
             public void onSuccess(int statusCode, Headers headers, JSON json) {
                 // clear out old items
+                if (mAdapter == null) return;
                 Log.d(TAG, "fetchTimelineAsync adapter tweets: " + mAdapter.getItemCount());
                 mAdapter.clear();
 
@@ -124,6 +132,7 @@ public class TimelineActivity extends AppCompatActivity {
                 populateHomeTimeline();
 
                 // signal refresh has finished
+                if (mSwipeContainer == null) return;
                 mSwipeContainer.setRefreshing(false);
             }
 
@@ -143,6 +152,7 @@ public class TimelineActivity extends AppCompatActivity {
                 JSONArray jsonArray = json.jsonArray;
                 try {
                     List<Tweet> ts = Tweet.fromJsonArray(jsonArray);
+                    if (mTweets == null || mAdapter == null) return;
                     mTweets.addAll(ts);
                     mAdapter.notifyDataSetChanged();
                 } catch (JSONException e) {

--- a/app/src/main/java/com/codepath/apps/restclienttemplate/TweetDetailActivity.java
+++ b/app/src/main/java/com/codepath/apps/restclienttemplate/TweetDetailActivity.java
@@ -1,5 +1,6 @@
 package com.codepath.apps.restclienttemplate;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Context;
@@ -153,4 +154,5 @@ public class TweetDetailActivity extends AppCompatActivity {
 
 
     }
+
 }

--- a/app/src/main/java/com/codepath/apps/restclienttemplate/TwitterClient.java
+++ b/app/src/main/java/com/codepath/apps/restclienttemplate/TwitterClient.java
@@ -103,7 +103,7 @@ public class TwitterClient extends OAuthBaseClient {
 					Log.i("TwitterClient", "Published tweet says: " + tweet.mBody);
 					Intent intent = new Intent();
 					intent.putExtra("tweet", Parcels.wrap(tweet));
-					activity.setResult(activity.RESULT_OK, intent);
+					activity.setResult(Activity.RESULT_OK, intent);
 					activity.finish(); // close activity and return to the parent
 				} catch (JSONException e) {
 					e.printStackTrace();

--- a/app/src/main/java/com/codepath/apps/restclienttemplate/adapters/TweetsAdapter.java
+++ b/app/src/main/java/com/codepath/apps/restclienttemplate/adapters/TweetsAdapter.java
@@ -200,6 +200,7 @@ public class TweetsAdapter extends RecyclerView.Adapter<TweetsAdapter.ViewHolder
                     i.putExtra("clickedTweet", Parcels.wrap(tweet));
                     i.putExtra("isReplying", true);
                     mContext.startActivity(i);
+
                 }
             });
 


### PR DESCRIPTION
In the async callbacks in `TimelineActivity`, I added null checks for code run on member variables. I also nullified member variables in `onDestroy`. 